### PR TITLE
Fix syntax error in logic

### DIFF
--- a/rofi-ykman
+++ b/rofi-ykman
@@ -5,7 +5,7 @@
 
 #2019 nukeop
 
-if [ ! $(ykman info) ]
+if [ ! "$(ykman info)" ]
 then
     notify-send "rofi-ykman" "Yubikey not detected."
     exit 1


### PR DESCRIPTION
Simple fix to prevent an error from being displayed in the terminal when this is ran by hand.  It works fine without this fix, it's just a little bit cleaner.

```
% ./rofi-ykman
./rofi-ykman: line 8: [: too many arguments
```