### PR TITLE
Add application name to notification

### DIFF
--- a/rofi-ykman
+++ b/rofi-ykman
@@ -7,7 +7,7 @@
 
 if [ ! "$(ykman info)" ]
 then
-    notify-send "rofi-ykman" "Yubikey not detected." -a "rofi-wkman"
+    notify-send "rofi-ykman" "Yubikey not detected." -a "rofi-ykman"
     exit 1
 fi
 

--- a/rofi-ykman
+++ b/rofi-ykman
@@ -7,7 +7,7 @@
 
 if [ ! "$(ykman info)" ]
 then
-    notify-send "rofi-ykman" "Yubikey not detected."
+    notify-send "rofi-ykman" "Yubikey not detected." -a "rofi-wkman"
     exit 1
 fi
 


### PR DESCRIPTION
This adds rofi-ykman as the application name to notification alerts. This stops some notification daemons like deadd-notification-center from identifying the notification as a notify-send notification