### PR TITLE
Add wayland support, environment detection & autotyper

### DIFF
--- a/rofi-ykman
+++ b/rofi-ykman
@@ -17,4 +17,18 @@ LAUNCHER="rofi -dmenu -i -p YubikeyOATH"
 option=`echo "${OPTIONS/, TOTP/\n}" | $LAUNCHER`
 code=$(ykman oath code "$option")
 IFS=', ' read -r -a code <<< "$code"
-echo "${code[-1]}" | xclip -selection clipboard
+if [ $XDG_SESSION_TYPE == "wayland" ]
+then
+		cliptool=wl-copy
+    typer="wtype -"
+else
+		cliptool=xclip -selection clipboard
+    typer="xargs xdotool type"
+fi
+if [ "$1" == "type" ]
+then
+    action=$typer
+else
+    action=$cliptool
+fi
+echo "${code[-1]}" | $action


### PR DESCRIPTION
The script will now work under wayland if wtype and wl-copy are installed.
The environment is automatically detected via $XDG_SESSION_TYPE
If the option 'type' is passed to the script, the output will be typed instead of copied to the clipboard.

Also added a TODO comment to add checks for presence of the used tools.